### PR TITLE
fix lowercase fish variable names for 2.7.0

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -25,8 +25,8 @@ function fish_right_prompt
         echo -sn "$color$status_code$color_normal "
     end
 
-    if test "$CMD_DURATION" -gt 250
-        set -l duration (echo $CMD_DURATION | humanize_duration)
+    if test "$cmd_duration" -gt 250
+        set -l duration (echo $cmd_duration | humanize_duration)
         echo -sn "$color$duration$color_normal "
     else
         set -l venv_name (basename "$VIRTUAL_ENV")


### PR DESCRIPTION
The fix works on my machine after downloading this version of the package ("fisher mgperry/mono"). Think this applies to most of your other themes as well unfortunately.